### PR TITLE
Relax patch level pronto restriction

### DIFF
--- a/pronto-eslint.gemspec
+++ b/pronto-eslint.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_dependency('pronto', '~> 0.6.0')
+  s.add_dependency('pronto', '~> 0.6')
   s.add_dependency('eslintrb', '~> 2.0', '>= 2.0.0')
   s.add_development_dependency('rake', '~> 11.0')
   s.add_development_dependency('rspec', '~> 3.4')


### PR DESCRIPTION
There isn't really a need to lock to a minor pronto version, and when using many pronto support gems, the chances of updating when one moves to a new minor version of pronto become very small. 
