### PR TITLE
Add .js.es6 as known filetype

### DIFF
--- a/lib/pronto/eslint.rb
+++ b/lib/pronto/eslint.rb
@@ -30,7 +30,7 @@ module Pronto
     end
 
     def js_file?(path)
-      %w(.js .es6).include? File.extname(path)
+      %w(.js .es6 .js.es6).include? File.extname(path)
     end
   end
 end


### PR DESCRIPTION
This is a commonly used filetype for es6 files.
