### PR TITLE
show fatal errors on wrong eslint config file specification

### DIFF
--- a/spec/fixtures/eslintrc8
+++ b/spec/fixtures/eslintrc8
@@ -1,0 +1,9 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 8,
+    "sourceType": "module"
+  },
+  "env": {
+    "browser": true
+    }
+}

--- a/spec/pronto/eslint_spec.rb
+++ b/spec/pronto/eslint_spec.rb
@@ -17,6 +17,22 @@ module Pronto
         it { should == [] }
       end
 
+      context 'invalid .eslintrc config' do
+        include_context 'test repo'
+        include_context 'eslintrc'
+
+        let(:patches) { repo.diff('master') }
+
+        its(:count) { should == 2 }
+
+        it 'all messages are parsing errors' do
+          subject.each { |element|
+            element.msg.should == 'Parsing error: ecmaVersion must be 3, 5, 6, or 7.'
+          }
+        end
+
+      end
+
       context 'patches with a four and a five warnings' do
         include_context 'test repo'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,14 @@ RSpec.shared_context 'test repo' do
   after { FileUtils.mv(dot_git, git) }
 end
 
+RSpec.shared_context 'eslintrc' do
+  let(:eslintrc) { 'spec/fixtures/eslintrc8' }
+  let(:dot_eslintrc) { '.eslintrc' }
+
+  before { FileUtils.mv(eslintrc, dot_eslintrc) }
+  after { FileUtils.mv(dot_eslintrc, eslintrc) }
+end
+
 RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = :should }
   config.mock_with(:rspec) { |c| c.syntax = :should }


### PR DESCRIPTION
When a .eslintrc file is using the latest version of ecmascript the runner just fails silently.
This also happens if the .eslintrc file has any error.

This PR will fix this and show these fatal errors as such.