### PR TITLE
Ensure commit sha is always passed to Message

### DIFF
--- a/lib/pronto/eslint.rb
+++ b/lib/pronto/eslint.rb
@@ -20,6 +20,8 @@ module Pronto
 
       return fatals if fatals && !fatals.empty?
 
+      # Use the line specific commit sha for non-fatal errors so that it can be better
+      # attributed to the specific commit.
       offences.map do |offence|
         patch.added_lines.select { |line| line.new_lineno == offence['line'] }
           .map { |line| new_message(offence, line, line.commit_sha) }

--- a/lib/pronto/eslint.rb
+++ b/lib/pronto/eslint.rb
@@ -42,7 +42,7 @@ module Pronto
       message = offence['message']
       message = "#{offence['ruleId']}: #{message}" if offence['ruleId']
 
-      Message.new(path, line, level, offence['message'], commit_sha, self.class)
+      Message.new(path, line, level, message, commit_sha, self.class)
     end
 
     def js_file?(path)

--- a/spec/pronto/eslint_spec.rb
+++ b/spec/pronto/eslint_spec.rb
@@ -29,6 +29,8 @@ module Pronto
           subject.each do |element|
             element.msg.should ==
               'Parsing error: ecmaVersion must be 3, 5, 6, or 7.'
+            element.commit_sha.should ==
+              '931004157205727e6a47586feaed0473c6ddbd66'
           end
         end
       end
@@ -40,6 +42,7 @@ module Pronto
 
         its(:count) { should == 9 }
         its(:'first.msg') { should == "curly: Expected { after 'if' condition." }
+        its(:'first.commit_sha') { should == "3a6237c5feacca9a37c36bec5110a1eeb9da703b" }
       end
     end
   end


### PR DESCRIPTION
In https://github.com/prontolabs/pronto-eslint/issues/18 the issue is raised the gitlab API cannot be correctly addressed with the gem in the state it is right now.

This seems to be happening because the commit sha is set to nil in any case https://github.com/prontolabs/pronto-eslint/blob/46848c9e2475c51a56285563adc0a886ccf7ab1c/lib/pronto/eslint.rb#L41

Lines would provide the commit sha correctly for the change and the error caused by it, but those are only accessed for non fatal errors.

The commit sha is also stored at the top level `@patches` variable which can provide it for the commit that was last pushed/on which the check is running. In for fatal errors it is possible then to use this commit message to attach the messages