### PR TITLE
Add offence.rule to the Pronto message

### DIFF
--- a/lib/pronto/eslint.rb
+++ b/lib/pronto/eslint.rb
@@ -37,8 +37,10 @@ module Pronto
     def new_message(offence, line)
       path = line ? line.patch.delta.new_file[:path] : '.eslintrc'
       level = line ? :warning : :fatal
+      message = offence['message']
+      message.insert(0, "#{offence['ruleId']}: ") if offence['ruleId']
 
-      Message.new(path, line, level, offence['message'], nil, self.class)
+      Message.new(path, line, level, message, nil, self.class)
     end
 
     def js_file?(path)

--- a/lib/pronto/eslint.rb
+++ b/lib/pronto/eslint.rb
@@ -38,7 +38,7 @@ module Pronto
       path = line ? line.patch.delta.new_file[:path] : '.eslintrc'
       level = line ? :warning : :fatal
       message = offence['message']
-      message.insert(0, "#{offence['ruleId']}: ") if offence['ruleId']
+      message = "#{offence['ruleId']}: #{message}" if offence['ruleId']
 
       Message.new(path, line, level, message, nil, self.class)
     end

--- a/spec/pronto/eslint_spec.rb
+++ b/spec/pronto/eslint_spec.rb
@@ -39,7 +39,7 @@ module Pronto
         let(:patches) { repo.diff('master') }
 
         its(:count) { should == 9 }
-        its(:'first.msg') { should == "Expected { after 'if' condition." }
+        its(:'first.msg') { should == "curly: Expected { after 'if' condition." }
       end
     end
   end


### PR DESCRIPTION
We would like to see which ESLint rule has been broken when running pronto. This would allow the developer to quickly disable the rule or read up about the rule online at a glance.

Example output with rule added.:
`Foobar.ts:96 W: @typescript-eslint/no-unused-vars: 'foo' is assigned a value but never used. Allowed unused vars must match /^_/u.`